### PR TITLE
Correction du bug d'affichage du mois sur les infos

### DIFF
--- a/src/hflan/LanBundle/Resources/translations/dates.fr.yml
+++ b/src/hflan/LanBundle/Resources/translations/dates.fr.yml
@@ -8,15 +8,15 @@ date:
         6: samedi
         7: dimanche
     month:
-        01: janvier
-        02: février
-        03: mars
-        04: avril
-        05: mais
-        06: juin
-        07: juillet
-        08: août
-        09: septembre
+        1: janvier
+        2: février
+        3: mars
+        4: avril
+        5: mais
+        6: juin
+        7: juillet
+        8: août
+        9: septembre
         10: octobre
         11: novembre
         12: décembre

--- a/src/hflan/LanBundle/Twig/DateExtension.php
+++ b/src/hflan/LanBundle/Twig/DateExtension.php
@@ -99,15 +99,15 @@ class DateExtension extends \Twig_Extension
             return $this->trans("date.weekend.sameMonth", array(
                 '%from%'=>$from->format('d'),
                 '%to%'=>$to->format('d'),
-                '%month%'=>$this->trans('date.month.'.$from->format('m')),
+                '%month%'=>$this->trans('date.month.'.$from->format('n')),
             ));
         }
 
         return $this->trans("date.weekend.differentMonth", array(
             '%from%'=>$from->format('d'),
             '%to%'=>$to->format('d'),
-            '%fromMonth%'=>$this->trans('date.month.'.$from->format('m')),
-            '%toMonth%'=>$this->trans('date.month.'.$to->format('m')),
+            '%fromMonth%'=>$this->trans('date.month.'.$from->format('n')),
+            '%toMonth%'=>$this->trans('date.month.'.$to->format('n')),
         ));
     }
 
@@ -117,15 +117,15 @@ class DateExtension extends \Twig_Extension
             return $this->trans("date.range.sameMonth", array(
                 '%from%'=>$from->format('d'),
                 '%to%'=>$to->format('d'),
-                '%month%'=>$this->trans('date.month.'.$from->format('m')),
+                '%month%'=>$this->trans('date.month.'.$from->format('n')),
             ));
         }
 
         return $this->trans("date.range.differentMonth", array(
             '%from%'=>$from->format('d'),
             '%to%'=>$to->format('d'),
-            '%fromMonth%'=>$this->trans('date.month.'.$from->format('m')),
-            '%toMonth%'=>$this->trans('date.month.'.$to->format('m')),
+            '%fromMonth%'=>$this->trans('date.month.'.$from->format('n')),
+            '%toMonth%'=>$this->trans('date.month.'.$to->format('n')),
         ));
     }
     


### PR DESCRIPTION
Pour une raison étrange, le YAML vire les zéros devant les noms des clés lorsque tu utilises une structure avec indentation. Regarde avec ce site : http://yaml-online-parser.appspot.com/
Je n'ai fait que virer les zéros en trop et j'ai modifié la fonction format pour que les zéros ne soient pas affichés.
